### PR TITLE
Add below-28 assist via SLC cap and UI display

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -78,6 +78,8 @@ struct FrogPilotPlan @0xda96579883444c35 {
   vCruise @29 :Float32;
   vtscControllingCurve @30 :Bool;
   vtscSpeed @31 :Float32;
+  below28AssistActive @32 :Bool;
+  below28AssistSpeed @33 :Float32;
 }
 
 struct CustomReserved4 @0x80ae746ee2596b11 {

--- a/selfdrive/frogpilot/controls/frogpilot_planner.py
+++ b/selfdrive/frogpilot/controls/frogpilot_planner.py
@@ -166,6 +166,9 @@ class FrogPilotPlanner:
     frogpilotPlan.unconfirmedSlcSpeedLimit = self.frogpilot_vcruise.slc.desired_speed_limit
     frogpilotPlan.upcomingSLCSpeedLimit = self.frogpilot_vcruise.slc.upcoming_speed_limit
 
+    frogpilotPlan.below28AssistActive = self.frogpilot_vcruise.below28_active
+    frogpilotPlan.below28AssistSpeed = float(self.frogpilot_vcruise.below28_target)
+
     frogpilotPlan.togglesUpdated = toggles_updated
 
     frogpilotPlan.vCruise = float(self.v_cruise)

--- a/selfdrive/frogpilot/controls/lib/frogpilot_vcruise.py
+++ b/selfdrive/frogpilot/controls/lib/frogpilot_vcruise.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import numpy as np
 
+from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.realtime import DT_MDL
 from openpilot.selfdrive.controls.lib.drive_helpers import V_CRUISE_MAX
@@ -11,6 +12,7 @@ from openpilot.selfdrive.frogpilot.controls.lib.speed_limit_controller import Sp
 from openpilot.selfdrive.frogpilot.frogpilot_variables import CRUISING_SPEED, PLANNER_TIME, State, params_memory
 
 TARGET_LAT_A = 2.0
+BELOW28_FLOOR_MPH = 28
 
 class FrogPilotVCruise:
   def __init__(self, FrogPilotPlanner):
@@ -24,11 +26,42 @@ class FrogPilotVCruise:
     self.override_slc = False
 
     self.mtsc_target = 0
+    self.below28_active = False
+    self.below28_target = 0
+    self.below28_ui_set_speed_mph = BELOW28_FLOOR_MPH
     self.overridden_speed = 0
     self.override_force_stop_timer = 0
     self.slc_offset = 0
     self.slc_target = 0
     self.speed_limit_timer = 0
+
+  def _update_below28_assist(self, carState, controlsState, v_cruise_cluster, speed_limit_changed):
+    if not carState.cruiseState.enabled or not controlsState.enabled:
+      self.below28_active = False
+
+    cancel_pressed = any(be.type == car.CarState.ButtonEvent.Type.cancel and be.pressed for be in carState.buttonEvents)
+    if cancel_pressed:
+      self.below28_active = False
+
+    if speed_limit_changed:
+      return
+
+    v_cruise_mph = int(round(v_cruise_cluster * CV.MS_TO_MPH))
+    decel_released = any(be.type == car.CarState.ButtonEvent.Type.decelCruise and not be.pressed for be in carState.buttonEvents)
+    accel_released = any(be.type == car.CarState.ButtonEvent.Type.accelCruise and not be.pressed for be in carState.buttonEvents)
+
+    if decel_released:
+      if self.below28_active:
+        self.below28_ui_set_speed_mph = max(1, self.below28_ui_set_speed_mph - 1)
+      elif v_cruise_mph == BELOW28_FLOOR_MPH:
+        self.below28_active = True
+        self.below28_ui_set_speed_mph = BELOW28_FLOOR_MPH - 1
+
+    if accel_released and self.below28_active:
+      self.below28_ui_set_speed_mph += 1
+
+    if self.below28_ui_set_speed_mph >= BELOW28_FLOOR_MPH:
+      self.below28_active = False
 
   def update(self, carState, controlsState, frogpilotCarState, frogpilotNavigation, gps_position, v_cruise, v_ego, frogpilot_toggles):
     force_stop = self.frogpilot_planner.cem.stop_light_detected and controlsState.enabled and frogpilot_toggles.force_stops
@@ -83,7 +116,8 @@ class FrogPilotVCruise:
       self.mtsc_target = v_cruise
 
     # Pfeiferj's Speed Limit Controller
-    if frogpilot_toggles.show_speed_limits or frogpilot_toggles.speed_limit_controller:
+    slc_active = frogpilot_toggles.show_speed_limits or frogpilot_toggles.speed_limit_controller
+    if slc_active:
       self.slc.update(frogpilotCarState.dashboardSpeedLimit, controlsState.enabled, frogpilotNavigation.navigationSpeedLimit, v_cruise_cluster, v_ego, frogpilot_toggles)
       desired_slc_target = self.slc.desired_speed_limit
 
@@ -130,6 +164,12 @@ class FrogPilotVCruise:
       self.slc_offset = 0
       self.slc_target = 0
 
+    self._update_below28_assist(carState, controlsState, v_cruise_cluster, self.slc.speed_limit_changed if slc_active else False)
+    if self.below28_active and self.below28_ui_set_speed_mph < BELOW28_FLOOR_MPH:
+      self.below28_target = self.below28_ui_set_speed_mph * CV.MPH_TO_MS
+    else:
+      self.below28_target = 0
+
     # Pfeiferj's Vision Turn Controller
     if v_ego > CRUISING_SPEED and controlsState.enabled and self.frogpilot_planner.road_curvature_detected and frogpilot_toggles.vision_turn_speed_controller:
       self.vtsc_target = ((TARGET_LAT_A * frogpilot_toggles.turn_aggressiveness) / (abs(self.frogpilot_planner.road_curvature) * frogpilot_toggles.curve_sensitivity))**0.5
@@ -153,6 +193,8 @@ class FrogPilotVCruise:
       targets = [self.braking_target, self.mtsc_target, self.vtsc_target]
       if frogpilot_toggles.speed_limit_controller:
         targets.append(max(self.overridden_speed, self.slc_target + self.slc_offset))
+      if self.below28_target > 0:
+        targets.append(self.below28_target)
 
       v_cruise = min([target if target > CRUISING_SPEED else v_cruise for target in targets])
 

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -58,6 +58,9 @@ void AnnotatedCameraWidget::updateState(int alert_height, const UIState &s) {
 
   // Handle older routes where vCruiseCluster is not set
   float v_cruise = cs.getVCruiseCluster() == 0.0 ? cs.getVCruise() : cs.getVCruiseCluster();
+  if (s.scene.below28_assist_active) {
+    v_cruise = s.scene.below28_assist_speed * MS_TO_KPH;
+  }
   setSpeed = cs_alive ? v_cruise : SET_SPEED_NA;
   is_cruise_set = setSpeed > 0 && (int)setSpeed != SET_SPEED_NA;
   if (is_cruise_set && !s.scene.is_metric) {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -316,6 +316,8 @@ static void update_state(UIState *s) {
     scene.lane_width_left = frogpilotPlan.getLaneWidthLeft();
     scene.lane_width_right = frogpilotPlan.getLaneWidthRight();
     scene.mtsc_speed = frogpilotPlan.getMtscSpeed();
+    scene.below28_assist_active = frogpilotPlan.getBelow28AssistActive();
+    scene.below28_assist_speed = frogpilotPlan.getBelow28AssistSpeed();
     scene.red_light = frogpilotPlan.getRedLight();
     scene.speed_jerk = frogpilotPlan.getSpeedJerk();
     scene.speed_jerk_difference = frogpilotPlan.getSpeedJerkStock() - scene.speed_jerk;

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -136,6 +136,7 @@ typedef struct UIScene {
   bool blind_spot_left;
   bool blind_spot_path;
   bool blind_spot_right;
+  bool below28_assist_active;
   bool brake_lights_on;
   bool cem_status;
   bool compass;
@@ -228,6 +229,7 @@ typedef struct UIScene {
   float acceleration;
   float acceleration_jerk;
   float acceleration_jerk_difference;
+  float below28_assist_speed;
   float dashboard_speed_limit;
   float friction;
   float lane_detection_width;


### PR DESCRIPTION
### Motivation

- Allow drivers to set cruise targets below 28 mph via stalk taps and have the car actually respect that request by routing the requested cap through the existing SLC-style enforcement path while leaving real map speed limits untouched and visible.

### Description

- Add `below28AssistActive` and `below28AssistSpeed` to `FrogPilotPlan` in `cereal/custom.capnp` to publish assist state and effective SLC cap.
- Implement a Below-28 state and button handling in `selfdrive/frogpilot/controls/lib/frogpilot_vcruise.py` that: detects the "at 28 + decel tap" entry, lets taps increment/decrement `ui_set_speed` below 28, cancels on `cancel` or when the ui set speed returns to 28, and produces `below28_target` (in m/s) when active.
- Enforce the below-28 request by appending `below28_target` to the same target list used for SLC enforcement so longitudinal planning clamps to the below-28 cap without changing the ECU cruise set speed path.
- Expose the below-28 assist values in `selfdrive/frogpilot/controls/frogpilot_planner.py` and wire them into the UI via `selfdrive/ui/ui.h` / `selfdrive/ui/ui.cc`; update `selfdrive/ui/qt/onroad/annotated_camera.cc` so the HUD shows the below-28 set speed when active while keeping the real road speed limit values unchanged.

### Testing

- No automated tests were run for this change (not requested); therefore no test results to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d1c9b1f08329b404832906f8db49)