### PR TITLE
Add below-28 assist reporting and HUD display

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -182,6 +182,8 @@ struct FrogPilotPlan @0xf98d843bfd7004a3 {
   vCruise @32 :Float32;
   weatherDaytime @33 :Bool;
   weatherId @34 :Int16;
+  below28AssistActive @35 :Bool;
+  below28AssistSpeed @36 :Float32;
 }
 
 struct FrogPilotRadarState @0xb86e6369214c01c8 {

--- a/frogpilot/controls/frogpilot_planner.py
+++ b/frogpilot/controls/frogpilot_planner.py
@@ -179,6 +179,8 @@ class FrogPilotPlanner:
     frogpilotPlan.slcSpeedLimitSource = self.frogpilot_vcruise.slc.source
     frogpilotPlan.speedLimitChanged = self.frogpilot_vcruise.slc.speed_limit_changed_timer > DT_MDL
     frogpilotPlan.unconfirmedSlcSpeedLimit = self.frogpilot_vcruise.slc.unconfirmed_speed_limit
+    frogpilotPlan.below28AssistActive = self.frogpilot_vcruise.below28_active
+    frogpilotPlan.below28AssistSpeed = float(self.frogpilot_vcruise.below28_target)
 
     frogpilotPlan.themeUpdated = theme_updated
 

--- a/frogpilot/controls/lib/frogpilot_vcruise.py
+++ b/frogpilot/controls/lib/frogpilot_vcruise.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+import math
+
+from cereal import car
 from openpilot.common.constants import CV
 from openpilot.common.realtime import DT_MDL
 
@@ -7,6 +10,7 @@ from openpilot.frogpilot.controls.lib.curve_speed_controller import CurveSpeedCo
 from openpilot.frogpilot.controls.lib.speed_limit_controller import SpeedLimitController
 
 OVERRIDE_FORCE_STOP_TIMER = 10
+BELOW28_FLOOR_MPH = 28
 
 class FrogPilotVCruise:
   def __init__(self, FrogPilotPlanner):
@@ -19,8 +23,81 @@ class FrogPilotVCruise:
     self.override_force_stop = False
 
     self.override_force_stop_timer = 0
+    self.below28_active = False
+    self.below28_target = 0
+    self.below28_ui_set_speed_mph = BELOW28_FLOOR_MPH
+    self.below28_resume = False
+    self.prev_long_control_active = False
+
+  def _update_below28_assist(self, car_state, long_control_active, v_cruise_cluster, speed_limit_changed, just_enabled, frogpilot_toggles):
+    if not car_state.cruiseState.enabled or not long_control_active:
+      if self.below28_active:
+        self.below28_resume = True
+      self.below28_active = False
+      return
+
+    v_cruise_mph = int(round(v_cruise_cluster * CV.MS_TO_MPH))
+    if just_enabled and self.below28_resume and self.below28_ui_set_speed_mph < BELOW28_FLOOR_MPH:
+      self.below28_active = True
+      self.below28_resume = False
+      return
+
+    if just_enabled and v_cruise_mph >= BELOW28_FLOOR_MPH:
+      self.below28_active = False
+      self.below28_ui_set_speed_mph = BELOW28_FLOOR_MPH
+      return
+
+    cancel_pressed = any(
+      event.type == car.CarState.ButtonEvent.Type.cancel and event.pressed
+      for event in car_state.buttonEvents
+    )
+    if cancel_pressed:
+      self.below28_active = False
+
+    if speed_limit_changed:
+      return
+
+    short_step_mph = 5 if frogpilot_toggles.reverse_cruise_increase else 1
+
+    button_type = None
+    for event in car_state.buttonEvents:
+      if event.type in (car.CarState.ButtonEvent.Type.decelCruise, car.CarState.ButtonEvent.Type.accelCruise) and event.pressed:
+        button_type = event.type
+        break
+      if event.type in (car.CarState.ButtonEvent.Type.decelCruise, car.CarState.ButtonEvent.Type.accelCruise) and not event.pressed:
+        button_type = event.type
+        break
+
+    if button_type is None:
+      return
+
+    if not self.below28_active and not (button_type == car.CarState.ButtonEvent.Type.decelCruise and v_cruise_mph == BELOW28_FLOOR_MPH):
+      return
+
+    if not self.below28_active:
+      self.below28_ui_set_speed_mph = v_cruise_mph
+
+    step_mph = short_step_mph
+    direction = 1 if button_type == car.CarState.ButtonEvent.Type.accelCruise else -1
+    if step_mph % 5 == 0 and self.below28_ui_set_speed_mph % step_mph != 0:
+      if direction > 0:
+        self.below28_ui_set_speed_mph = int(math.ceil(self.below28_ui_set_speed_mph / step_mph) * step_mph)
+      else:
+        self.below28_ui_set_speed_mph = int(math.floor(self.below28_ui_set_speed_mph / step_mph) * step_mph)
+    else:
+      self.below28_ui_set_speed_mph += step_mph * direction
+
+    self.below28_ui_set_speed_mph = max(1, self.below28_ui_set_speed_mph)
+
+    if not self.below28_active and button_type == car.CarState.ButtonEvent.Type.decelCruise and v_cruise_mph == BELOW28_FLOOR_MPH:
+      self.below28_active = True
+      self.below28_ui_set_speed_mph = max(1, min(self.below28_ui_set_speed_mph, BELOW28_FLOOR_MPH - 1))
+
+    if self.below28_ui_set_speed_mph >= BELOW28_FLOOR_MPH:
+      self.below28_active = False
 
   def update(self, long_control_active, now, time_validated, v_cruise, v_ego, sm, frogpilot_toggles):
+    just_enabled = long_control_active and not self.prev_long_control_active
     force_stop = self.frogpilot_planner.frogpilot_cem.stop_light_detected and long_control_active and frogpilot_toggles.force_stops
     force_stop &= self.frogpilot_planner.model_stopped
     force_stop &= self.override_force_stop_timer <= 0
@@ -62,6 +139,7 @@ class FrogPilotVCruise:
     # Pfeiferj's Speed Limit Controller
     self.slc.frogpilot_toggles = frogpilot_toggles
 
+    slc_active = frogpilot_toggles.speed_limit_controller or frogpilot_toggles.show_speed_limits
     if frogpilot_toggles.speed_limit_controller:
       self.slc.update_limits(sm["frogpilotCarState"].dashboardSpeedLimit, now, time_validated, v_cruise, v_ego, sm)
       self.slc.update_override(v_cruise, v_cruise_diff, v_ego, v_ego_diff, sm)
@@ -77,6 +155,13 @@ class FrogPilotVCruise:
       self.slc_offset = 0
       self.slc_target = 0
 
+    speed_limit_changed = self.slc.speed_limit_changed_timer > DT_MDL if slc_active else False
+    self._update_below28_assist(sm["carState"], long_control_active, v_cruise_cluster, speed_limit_changed, just_enabled, frogpilot_toggles)
+    if self.below28_active and self.below28_ui_set_speed_mph < BELOW28_FLOOR_MPH:
+      self.below28_target = self.below28_ui_set_speed_mph * CV.MPH_TO_MS
+    else:
+      self.below28_target = 0
+
     if force_stop_enabled and not self.override_force_stop:
       self.forcing_stop |= not sm["carState"].standstill
 
@@ -91,6 +176,9 @@ class FrogPilotVCruise:
       targets = [self.csc_target, v_cruise]
       if frogpilot_toggles.speed_limit_controller:
         targets.append(max(self.slc.overridden_speed, self.slc_target + self.slc_offset) - v_ego_diff)
+      if self.below28_target > 0:
+        targets.append(self.below28_target)
       v_cruise = min([target if target >= CRUISING_SPEED else v_cruise for target in targets])
 
+    self.prev_long_control_active = long_control_active
     return v_cruise

--- a/frogpilot/ui/frogpilot_ui.cc
+++ b/frogpilot/ui/frogpilot_ui.cc
@@ -17,6 +17,8 @@ static void update_state(FrogPilotUIState *fs) {
   }
   if (fpsm.updated("frogpilotPlan")) {
     const cereal::FrogPilotPlan::Reader &frogpilotPlan = fpsm["frogpilotPlan"].getFrogpilotPlan();
+    frogpilot_scene.below28_assist_active = frogpilotPlan.getBelow28AssistActive();
+    frogpilot_scene.below28_assist_speed = frogpilotPlan.getBelow28AssistSpeed();
     if (frogpilotPlan.getThemeUpdated()) {
       emit fs->themeUpdated();
     }

--- a/frogpilot/ui/frogpilot_ui.h
+++ b/frogpilot/ui/frogpilot_ui.h
@@ -7,6 +7,7 @@
 
 struct FrogPilotUIScene {
   bool always_on_lateral_active;
+  bool below28_assist_active;
   bool downloading_update;
   bool enabled;
   bool frogpilot_panel_active;
@@ -22,6 +23,7 @@ struct FrogPilotUIScene {
   int driver_camera_timer;
   int started_timer;
 
+  float below28_assist_speed;
   QJsonObject frogpilot_toggles;
 };
 

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -179,7 +179,7 @@ void AnnotatedCameraWidget::paintEvent(QPaintEvent *event) {
 
   model.draw(painter, rect());
   dmon.draw(painter, rect());
-  hud.updateState(*s);
+  hud.updateState(*s, frogpilot_scene);
   hud.draw(painter, rect());
 
   // FrogPilot variables

--- a/selfdrive/ui/qt/onroad/hud.cc
+++ b/selfdrive/ui/qt/onroad/hud.cc
@@ -8,7 +8,7 @@ constexpr int SET_SPEED_NA = 255;
 
 HudRenderer::HudRenderer() {}
 
-void HudRenderer::updateState(const UIState &s) {
+void HudRenderer::updateState(const UIState &s, const FrogPilotUIScene &frogpilot_scene) {
   is_metric = s.scene.is_metric;
   status = s.status;
 
@@ -25,6 +25,9 @@ void HudRenderer::updateState(const UIState &s) {
 
   // Handle older routes where vCruiseCluster is not set
   set_speed = car_state.getVCruiseCluster() == 0.0 ? controls_state.getVCruiseDEPRECATED() : car_state.getVCruiseCluster();
+  if (frogpilot_scene.below28_assist_active) {
+    set_speed = frogpilot_scene.below28_assist_speed * MS_TO_KPH;
+  }
   is_cruise_set = set_speed > 0 && set_speed != SET_SPEED_NA;
   is_cruise_available = set_speed != -1;
 

--- a/selfdrive/ui/qt/onroad/hud.h
+++ b/selfdrive/ui/qt/onroad/hud.h
@@ -10,7 +10,7 @@ class HudRenderer : public QObject {
 
 public:
   HudRenderer();
-  void updateState(const UIState &s);
+  void updateState(const UIState &s, const FrogPilotUIScene &frogpilot_scene);
   void draw(QPainter &p, const QRect &surface_rect);
 
   // FrogPilot variables


### PR DESCRIPTION
### Motivation
- Surface and persist the below-28 cruise assist UI state so the HUD can show a below-28 set speed and other systems can react to the assist.
- Integrate the below-28 assist into the cruise target selection so it can cap/override cruise when active.
- Propagate the assist state from the v-cruise controller through the planner message into the FrogPilot UI scene for display.

### Description
- Add `below28AssistActive` and `below28AssistSpeed` to `FrogPilotPlan` in `cereal/custom.capnp` to transport the assist state.
- Implement below-28 assist logic in `frogpilot/controls/lib/frogpilot_vcruise.py` with `_update_below28_assist`, track UI set speed, resume/cancel behavior, and expose `below28_target` as an additional cruise target.
- Publish the v-cruise assist state from the planner in `frogpilot/controls/frogpilot_planner.py` using the new `FrogPilotPlan` fields.
- Surface the values to the UI by adding fields to the FrogPilot UI scene in `frogpilot/ui/frogpilot_ui.h` and reading the plan values in `frogpilot/ui/frogpilot_ui.cc`.
- Wire the HUD to honor the below-28 assist display by updating `HudRenderer::updateState` signature in `selfdrive/ui/qt/onroad/hud.h`/`hud.cc` and passing the FrogPilot scene from `selfdrive/ui/qt/onroad/annotated_camera.cc` so `set_speed` can be overridden when the assist is active.
- Minor changes: import `cereal.car` and `math` for button handling and rounding logic, and refine cruise button event handling to consider pressed/released events.

### Testing
- No automated tests were run for this change (none requested or executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967fc9c05b08329b4e01da0899563be)