### PR TITLE
Add below-28 assist via SLC cap and UI display

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -217,6 +217,8 @@ struct FrogPilotPlan @0xa1680744031fdb2d {
   trackingLead @33 :Bool;
   unconfirmedSlcSpeedLimit @34 :Float32;
   vCruise @35 :Float32;
+  below28AssistActive @38 :Bool;
+  below28AssistSpeed @39 :Float32;
   weatherDaytime @36 :Bool;
   weatherId @37 :Int16;
 }

--- a/frogpilot/controls/frogpilot_planner.py
+++ b/frogpilot/controls/frogpilot_planner.py
@@ -176,6 +176,9 @@ class FrogPilotPlanner:
     frogpilotPlan.speedLimitChanged = self.frogpilot_vcruise.slc.speed_limit_changed_timer > DT_MDL
     frogpilotPlan.unconfirmedSlcSpeedLimit = self.frogpilot_vcruise.slc.unconfirmed_speed_limit
 
+    frogpilotPlan.below28AssistActive = self.frogpilot_vcruise.below28_active
+    frogpilotPlan.below28AssistSpeed = float(self.frogpilot_vcruise.below28_target)
+
     frogpilotPlan.themeUpdated = theme_updated or params_memory.get_bool("UseActiveTheme")
 
     frogpilotPlan.togglesUpdated = toggles_updated

--- a/frogpilot/controls/lib/frogpilot_vcruise.py
+++ b/frogpilot/controls/lib/frogpilot_vcruise.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+import math
+
+from cereal import car
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.realtime import DT_MDL
 from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import COMFORT_BRAKE
@@ -6,6 +9,8 @@ from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import COMFO
 from openpilot.frogpilot.common.frogpilot_variables import CRUISING_SPEED, PLANNER_TIME
 from openpilot.frogpilot.controls.lib.curve_speed_controller import CurveSpeedController
 from openpilot.frogpilot.controls.lib.speed_limit_controller import SpeedLimitController
+
+BELOW28_FLOOR_MPH = 28
 
 class FrogPilotVCruise:
   def __init__(self, FrogPilotPlanner):
@@ -18,8 +23,79 @@ class FrogPilotVCruise:
     self.override_force_stop = False
 
     self.override_force_stop_timer = 0
+    self.below28_active = False
+    self.below28_target = 0
+    self.below28_ui_set_speed_mph = BELOW28_FLOOR_MPH
+    self.below28_resume = False
+    self.prev_controls_enabled = False
+
+  def _update_below28_assist(self, car_state, controls_state, v_cruise_cluster, speed_limit_changed, just_enabled, frogpilot_toggles):
+    if not car_state.cruiseState.enabled or not controls_state.enabled:
+      if self.below28_active:
+        self.below28_resume = True
+      self.below28_active = False
+      return
+
+    v_cruise_mph = int(round(v_cruise_cluster * CV.MS_TO_MPH))
+    if just_enabled and self.below28_resume and self.below28_ui_set_speed_mph < BELOW28_FLOOR_MPH:
+      self.below28_active = True
+      self.below28_resume = False
+      return
+
+    if just_enabled and v_cruise_mph >= BELOW28_FLOOR_MPH:
+      self.below28_active = False
+      self.below28_ui_set_speed_mph = BELOW28_FLOOR_MPH
+      return
+
+    cancel_pressed = any(be.type == car.CarState.ButtonEvent.Type.cancel and be.pressed for be in car_state.buttonEvents)
+    if cancel_pressed:
+      self.below28_active = False
+
+    if speed_limit_changed:
+      return
+
+    short_step_mph = 5 if frogpilot_toggles.reverse_cruise_increase else 1
+
+    button_type = None
+    for event in car_state.buttonEvents:
+      if event.type in (car.CarState.ButtonEvent.Type.decelCruise, car.CarState.ButtonEvent.Type.accelCruise) and event.pressed:
+        button_type = event.type
+        break
+      if event.type in (car.CarState.ButtonEvent.Type.decelCruise, car.CarState.ButtonEvent.Type.accelCruise) and not event.pressed:
+        button_type = event.type
+        break
+
+    if button_type is None:
+      return
+
+    if not self.below28_active and not (button_type == car.CarState.ButtonEvent.Type.decelCruise and v_cruise_mph == BELOW28_FLOOR_MPH):
+      return
+
+    if not self.below28_active:
+      self.below28_ui_set_speed_mph = v_cruise_mph
+
+    step_mph = short_step_mph
+    direction = 1 if button_type == car.CarState.ButtonEvent.Type.accelCruise else -1
+    if step_mph % 5 == 0 and self.below28_ui_set_speed_mph % step_mph != 0:
+      if direction > 0:
+        self.below28_ui_set_speed_mph = int(math.ceil(self.below28_ui_set_speed_mph / step_mph) * step_mph)
+      else:
+        self.below28_ui_set_speed_mph = int(math.floor(self.below28_ui_set_speed_mph / step_mph) * step_mph)
+    else:
+      self.below28_ui_set_speed_mph += step_mph * direction
+
+    self.below28_ui_set_speed_mph = max(1, self.below28_ui_set_speed_mph)
+
+    if not self.below28_active and button_type == car.CarState.ButtonEvent.Type.decelCruise and v_cruise_mph == BELOW28_FLOOR_MPH:
+      self.below28_active = True
+      self.below28_ui_set_speed_mph = max(1, min(self.below28_ui_set_speed_mph, BELOW28_FLOOR_MPH - 1))
+
+    if self.below28_ui_set_speed_mph >= BELOW28_FLOOR_MPH:
+      self.below28_active = False
 
   def update(self, gps_position, now, time_validated, v_cruise, v_ego, sm, frogpilot_toggles):
+    controls_enabled = sm["controlsState"].enabled
+    just_enabled = controls_enabled and not self.prev_controls_enabled
     force_stop = self.frogpilot_planner.cem.stop_light_detected and sm["controlsState"].enabled and frogpilot_toggles.force_stops
     force_stop &= self.frogpilot_planner.model_stopped
     force_stop &= self.override_force_stop_timer <= 0
@@ -61,6 +137,7 @@ class FrogPilotVCruise:
     # Pfeiferj's Speed Limit Controller
     self.slc.frogpilot_toggles = frogpilot_toggles
 
+    slc_active = frogpilot_toggles.show_speed_limits or frogpilot_toggles.speed_limit_controller
     if frogpilot_toggles.speed_limit_controller:
       self.slc.update_limits(sm["frogpilotCarState"].dashboardSpeedLimit, gps_position, sm["frogpilotNavigation"].navigationSpeedLimit, now, time_validated, v_cruise, v_ego, sm)
       self.slc.update_override(v_cruise, v_cruise_diff, v_ego, v_ego_diff, sm)
@@ -76,6 +153,19 @@ class FrogPilotVCruise:
       self.slc_offset = 0
       self.slc_target = 0
 
+    self._update_below28_assist(
+      sm["carState"],
+      sm["controlsState"],
+      v_cruise_cluster,
+      self.slc.speed_limit_changed_timer > DT_MDL if slc_active else False,
+      just_enabled,
+      frogpilot_toggles,
+    )
+    if self.below28_active and self.below28_ui_set_speed_mph < BELOW28_FLOOR_MPH:
+      self.below28_target = self.below28_ui_set_speed_mph * CV.MPH_TO_MS
+    else:
+      self.below28_target = 0
+
     if force_stop_enabled and not self.override_force_stop:
       self.forcing_stop |= not sm["carState"].standstill
 
@@ -90,7 +180,10 @@ class FrogPilotVCruise:
       targets = [self.csc_target, v_cruise]
       if frogpilot_toggles.speed_limit_controller:
         targets.append(max(self.slc.overridden_speed, self.slc_target + self.slc_offset) - v_ego_diff)
+      if self.below28_target > 0:
+        targets.append(self.below28_target)
 
       v_cruise = min([target if target >= CRUISING_SPEED else v_cruise for target in targets])
 
+    self.prev_controls_enabled = controls_enabled
     return v_cruise

--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -59,6 +59,9 @@ void AnnotatedCameraWidget::updateState(const UIState &s, const FrogPilotUIState
 
   // Handle older routes where vCruiseCluster is not set
   float v_cruise = cs.getVCruiseCluster() == 0.0 ? cs.getVCruise() : cs.getVCruiseCluster();
+  if (frogpilotPlan.getBelow28AssistActive()) {
+    v_cruise = frogpilotPlan.getBelow28AssistSpeed() * MS_TO_KPH;
+  }
   setSpeed = cs_alive ? v_cruise : SET_SPEED_NA;
   is_cruise_set = setSpeed > 0 && (int)setSpeed != SET_SPEED_NA;
   if (is_cruise_set && !s.scene.is_metric) {


### PR DESCRIPTION
### Motivation
- Support a new "below-28" cruise assist mode that lets the planner accept targets below the usual 28 mph floor and expose that state to the UI and other consumers.
- Provide a way for the SLC/UI to display and use the below-28 target when the assist is active.

### Description
- Added `below28AssistActive` and `below28AssistSpeed` fields to `FrogPilotPlan` in `cereal/custom.capnp` for downstream consumers to read the state and target.
- Publish the below-28 assist state and target from the planner by setting `frogpilotPlan.below28AssistActive` and `frogpilotPlan.below28AssistSpeed` in `frogpilot/controls/frogpilot_planner.py`.
- Implement below-28 assist handling and target selection in `frogpilot/controls/lib/frogpilot_vcruise.py`, including UI-set speed bookkeeping, button handling, resume/cancel logic, and integration into vCruise target selection with a `BELOW28_FLOOR_MPH` constant.
- Update `selfdrive/ui/qt/onroad/annotated_camera.cc` to display the below-28 assist target as the on-road set speed when the assist is active.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968120e0a648329929c3585d00dbe7d)