### PR TITLE
Fix below-28 cruise entry when using 5 mph steps

### DIFF
--- a/frogpilot/controls/lib/frogpilot_vcruise.py
+++ b/frogpilot/controls/lib/frogpilot_vcruise.py
@@ -68,7 +68,10 @@ class FrogPilotVCruise:
     if button_type is None:
       return
 
-    if not self.below28_active and not (button_type == car.CarState.ButtonEvent.Type.decelCruise and v_cruise_mph == BELOW28_FLOOR_MPH):
+    can_enter_below28 = button_type == car.CarState.ButtonEvent.Type.decelCruise and (
+      v_cruise_mph <= BELOW28_FLOOR_MPH or (v_cruise_mph - short_step_mph) < BELOW28_FLOOR_MPH
+    )
+    if not self.below28_active and not can_enter_below28:
       return
 
     if not self.below28_active:
@@ -86,7 +89,7 @@ class FrogPilotVCruise:
 
     self.below28_ui_set_speed_mph = max(1, self.below28_ui_set_speed_mph)
 
-    if not self.below28_active and button_type == car.CarState.ButtonEvent.Type.decelCruise and v_cruise_mph == BELOW28_FLOOR_MPH:
+    if not self.below28_active and button_type == car.CarState.ButtonEvent.Type.decelCruise and self.below28_ui_set_speed_mph < BELOW28_FLOOR_MPH:
       self.below28_active = True
       self.below28_ui_set_speed_mph = max(1, min(self.below28_ui_set_speed_mph, BELOW28_FLOOR_MPH - 1))
 


### PR DESCRIPTION
### Motivation
- Allow the below-28 assist to be entered when a single 5 mph decrement tap would cross the 28 mph floor, fixing the inability to set speeds under 28 mph when `reverse_cruise_increase` produces 5 mph steps.

### Description
- Change `frogpilot/controls/lib/frogpilot_vcruise.py` to compute `can_enter_below28` using `short_step_mph` and allow entry when `v_cruise_mph <= BELOW28_FLOOR_MPH` or `(v_cruise_mph - short_step_mph) < BELOW28_FLOOR_MPH`, and activate below-28 mode based on the resulting `below28_ui_set_speed_mph < BELOW28_FLOOR_MPH`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69682ab3406c8329bbaff97db91adef0)