### PR TITLE
Normalize cruise button enums in below-28 assist

### DIFF
--- a/frogpilot/controls/lib/frogpilot_vcruise.py
+++ b/frogpilot/controls/lib/frogpilot_vcruise.py
@@ -70,6 +70,12 @@ class FrogPilotVCruise:
 
     if button_type is None:
       return
+    try:
+      button_type = car.CarState.ButtonEvent.Type(button_type.raw)
+    except AttributeError:
+      button_type = car.CarState.ButtonEvent.Type(button_type)
+    except ValueError:
+      return
 
     can_enter_below28 = button_type == car.CarState.ButtonEvent.Type.decelCruise and (
       v_cruise_kph <= BELOW28_FLOOR_KPH or (v_cruise_kph - v_cruise_delta_kph) < BELOW28_FLOOR_KPH


### PR DESCRIPTION
### Motivation
- Prevent a crash/lookup failure in the below-28 assist when a cruise button event carries an unexpected or differently-typed value while spamming 5-step adjustments around 28 mph.
- Ensure lookups into `CRUISE_INTERVAL_SIGN` and `CRUISE_NEAREST_FUNC` use the expected `car.CarState.ButtonEvent.Type` enum.

### Description
- In `frogpilot/controls/lib/frogpilot_vcruise.py` coerce the captured `button_type` to the expected enum by attempting `car.CarState.ButtonEvent.Type(button_type.raw)` and falling back to `car.CarState.ButtonEvent.Type(button_type)`, with an early return on `ValueError`.
- Replace the previous safe-lookup fallback logic with a normalized direct indexing into `CRUISE_INTERVAL_SIGN` using the coerced `button_type`.
- All below-28 entry/exit checks and the UI speed adjustment logic remain otherwise unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69683bc621788329bc395c4994181ef7)