### PR TITLE
Add below-28 cruise assist plumbing and UI override

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -219,6 +219,8 @@ struct FrogPilotPlan @0xa1680744031fdb2d {
   vCruise @35 :Float32;
   weatherDaytime @36 :Bool;
   weatherId @37 :Int16;
+  below28AssistActive @38 :Bool;
+  below28AssistUiSetSpeedKph @39 :Float32;
 }
 
 struct FrogPilotRadarState @0xcb9fd56c7057593a {

--- a/frogpilot/controls/frogpilot_planner.py
+++ b/frogpilot/controls/frogpilot_planner.py
@@ -141,6 +141,9 @@ class FrogPilotPlanner:
     frogpilotPlan.cscSpeed = self.frogpilot_vcruise.csc_target
     frogpilotPlan.cscTraining = self.frogpilot_vcruise.csc.enable_training
 
+    frogpilotPlan.below28AssistActive = self.frogpilot_vcruise.below28_assist_active
+    frogpilotPlan.below28AssistUiSetSpeedKph = self.frogpilot_vcruise.below28_ui_set_speed_kph
+
     frogpilotPlan.desiredFollowDistance = self.frogpilot_following.desired_follow_distance
 
     frogpilotPlan.experimentalMode = self.cem.experimental_mode or self.frogpilot_vcruise.slc.experimental_mode

--- a/frogpilot/controls/lib/below28_assist.py
+++ b/frogpilot/controls/lib/below28_assist.py
@@ -20,6 +20,7 @@ class Below28Assist:
     self.active = False
     self.ui_set_speed_kph = 0.0
     self.cap_mps = 0.0
+    self.last_below28_set_kph = 0.0
 
     self.button_timers = {ButtonType.decelCruise: 0, ButtonType.accelCruise: 0}
     self.button_change_states = {btn: {"standstill": False, "enabled": False} for btn in self.button_timers}
@@ -29,18 +30,20 @@ class Below28Assist:
     self.ui_set_speed_kph = 0.0
     self.cap_mps = 0.0
 
-  def update(self, v_cruise_kph, v_ego_diff, CS, enabled, speed_limit_changed, frogpilot_toggles):
-    if not enabled:
+  def update(self, v_cruise_kph, v_ego, v_ego_diff, CS, enabled, speed_limit_changed, frogpilot_toggles):
+    if not enabled and not CS.cruiseState.enabled:
       self.reset()
       self.update_button_timers(CS, enabled)
       return
 
     current_speed_kph = self.ui_set_speed_kph if self.active else v_cruise_kph
-    updated_speed = self.update_set_speed(current_speed_kph, CS, enabled, speed_limit_changed, frogpilot_toggles)
+    updated_speed = self.update_set_speed(current_speed_kph, v_ego, v_ego_diff, CS, enabled, speed_limit_changed, frogpilot_toggles)
 
     if updated_speed is not None:
       self.ui_set_speed_kph = updated_speed
       self.active = self.ui_set_speed_kph < BELOW_28_KPH
+      if self.active:
+        self.last_below28_set_kph = self.ui_set_speed_kph
     elif self.active and self.ui_set_speed_kph >= BELOW_28_KPH:
       self.active = False
 
@@ -54,14 +57,23 @@ class Below28Assist:
 
     self.update_button_timers(CS, enabled)
 
-  def update_set_speed(self, v_cruise_kph, CS, enabled, speed_limit_changed, frogpilot_toggles):
-    if not enabled:
+  def update_set_speed(self, v_cruise_kph, v_ego, v_ego_diff, CS, enabled, speed_limit_changed, frogpilot_toggles):
+    if not enabled and not CS.cruiseState.enabled:
       return None
 
     long_press = False
     button_type = None
 
     for b in CS.buttonEvents:
+      if b.type.raw in (ButtonType.setCruise, ButtonType.resumeCruise) and not b.pressed:
+        if speed_limit_changed:
+          return None
+        if b.type.raw == ButtonType.resumeCruise and self.last_below28_set_kph > 0:
+          return self.last_below28_set_kph
+        if b.type.raw == ButtonType.setCruise:
+          v_ego_cluster = v_ego + v_ego_diff
+          set_speed_kph = v_ego_cluster * CV.MS_TO_KPH
+          return clip(round(set_speed_kph, 1), V_CRUISE_MIN, V_CRUISE_MAX)
       if b.type.raw in self.button_timers and not b.pressed:
         if self.button_timers[b.type.raw] > CRUISE_LONG_PRESS:
           return None

--- a/frogpilot/controls/lib/below28_assist.py
+++ b/frogpilot/controls/lib/below28_assist.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from openpilot.common.conversions import Conversions as CV
+from openpilot.common.numpy_fast import clip
+from openpilot.selfdrive.controls.lib.drive_helpers import (
+  ButtonType,
+  CRUISE_INTERVAL_SIGN,
+  CRUISE_LONG_PRESS,
+  CRUISE_NEAREST_FUNC,
+  IMPERIAL_INCREMENT,
+  V_CRUISE_MAX,
+  V_CRUISE_MIN,
+)
+
+BELOW_28_MPH = 28
+BELOW_28_KPH = BELOW_28_MPH * CV.MPH_TO_KPH
+
+
+class Below28Assist:
+  def __init__(self):
+    self.active = False
+    self.ui_set_speed_kph = 0.0
+    self.cap_mps = 0.0
+
+    self.button_timers = {ButtonType.decelCruise: 0, ButtonType.accelCruise: 0}
+    self.button_change_states = {btn: {"standstill": False, "enabled": False} for btn in self.button_timers}
+
+  def reset(self):
+    self.active = False
+    self.ui_set_speed_kph = 0.0
+    self.cap_mps = 0.0
+
+  def update(self, v_cruise_kph, v_ego_diff, CS, enabled, speed_limit_changed, frogpilot_toggles):
+    if not enabled:
+      self.reset()
+      self.update_button_timers(CS, enabled)
+      return
+
+    current_speed_kph = self.ui_set_speed_kph if self.active else v_cruise_kph
+    updated_speed = self.update_set_speed(current_speed_kph, CS, enabled, speed_limit_changed, frogpilot_toggles)
+
+    if updated_speed is not None:
+      self.ui_set_speed_kph = updated_speed
+      self.active = self.ui_set_speed_kph < BELOW_28_KPH
+    elif self.active and self.ui_set_speed_kph >= BELOW_28_KPH:
+      self.active = False
+
+    if not self.active:
+      self.ui_set_speed_kph = v_cruise_kph
+
+    if self.active:
+      self.cap_mps = max(self.ui_set_speed_kph * CV.KPH_TO_MS - v_ego_diff, 0.0)
+    else:
+      self.cap_mps = 0.0
+
+    self.update_button_timers(CS, enabled)
+
+  def update_set_speed(self, v_cruise_kph, CS, enabled, speed_limit_changed, frogpilot_toggles):
+    if not enabled:
+      return None
+
+    long_press = False
+    button_type = None
+
+    for b in CS.buttonEvents:
+      if b.type.raw in self.button_timers and not b.pressed:
+        if self.button_timers[b.type.raw] > CRUISE_LONG_PRESS:
+          return None
+        button_type = b.type.raw
+        break
+    else:
+      for k in self.button_timers.keys():
+        if self.button_timers[k] and self.button_timers[k] % CRUISE_LONG_PRESS == 0:
+          button_type = k
+          long_press = True
+          break
+
+    if button_type is None:
+      return None
+
+    if speed_limit_changed:
+      return None
+
+    cruise_standstill = self.button_change_states[button_type]["standstill"] or CS.cruiseState.standstill
+    if button_type == ButtonType.accelCruise and cruise_standstill:
+      return None
+
+    if not self.button_change_states[button_type]["enabled"]:
+      return None
+
+    v_cruise_delta = 1.0 if frogpilot_toggles.is_metric else IMPERIAL_INCREMENT
+
+    tap_increment = frogpilot_toggles.cruise_increase
+    hold_increment = frogpilot_toggles.cruise_increase_long
+    if frogpilot_toggles.reverse_cruise_increase:
+      tap_increment, hold_increment = hold_increment, tap_increment
+
+    v_cruise_delta_interval = hold_increment if long_press else tap_increment
+    v_cruise_delta *= v_cruise_delta_interval
+
+    if v_cruise_delta_interval % 5 == 0 and v_cruise_kph % v_cruise_delta != 0:
+      v_cruise_kph = CRUISE_NEAREST_FUNC[button_type](v_cruise_kph / v_cruise_delta) * v_cruise_delta
+    else:
+      v_cruise_kph += v_cruise_delta * CRUISE_INTERVAL_SIGN[button_type]
+
+    v_cruise_kph = clip(round(v_cruise_kph, 1), V_CRUISE_MIN, V_CRUISE_MAX)
+
+    return v_cruise_kph
+
+  def update_button_timers(self, CS, enabled):
+    for k in self.button_timers:
+      if self.button_timers[k] > 0:
+        self.button_timers[k] += 1
+
+    for b in CS.buttonEvents:
+      if b.type.raw in self.button_timers:
+        self.button_timers[b.type.raw] = 1 if b.pressed else 0
+        self.button_change_states[b.type.raw] = {"standstill": CS.cruiseState.standstill, "enabled": enabled}

--- a/frogpilot/controls/lib/below28_assist.py
+++ b/frogpilot/controls/lib/below28_assist.py
@@ -29,15 +29,22 @@ class Below28Assist:
     self.active = False
     self.ui_set_speed_kph = 0.0
     self.cap_mps = 0.0
+    self.reset_button_timers()
+
+  def reset_button_timers(self):
+    for button_type in self.button_timers:
+      self.button_timers[button_type] = 0
+      self.button_change_states[button_type] = {"standstill": False, "enabled": False}
 
   def update(self, v_cruise_kph, v_ego, v_ego_diff, CS, enabled, speed_limit_changed, frogpilot_toggles):
-    if not enabled and not CS.cruiseState.enabled:
+    buttons_enabled = enabled or CS.cruiseState.enabled
+    if not buttons_enabled:
       self.reset()
-      self.update_button_timers(CS, enabled)
+      self.update_button_timers(CS, buttons_enabled)
       return
 
     current_speed_kph = self.ui_set_speed_kph if self.active else v_cruise_kph
-    updated_speed = self.update_set_speed(current_speed_kph, v_ego, v_ego_diff, CS, enabled, speed_limit_changed, frogpilot_toggles)
+    updated_speed = self.update_set_speed(current_speed_kph, v_ego, v_ego_diff, CS, buttons_enabled, speed_limit_changed, frogpilot_toggles)
 
     if updated_speed is not None:
       self.ui_set_speed_kph = updated_speed
@@ -55,10 +62,10 @@ class Below28Assist:
     else:
       self.cap_mps = 0.0
 
-    self.update_button_timers(CS, enabled)
+    self.update_button_timers(CS, buttons_enabled)
 
-  def update_set_speed(self, v_cruise_kph, v_ego, v_ego_diff, CS, enabled, speed_limit_changed, frogpilot_toggles):
-    if not enabled and not CS.cruiseState.enabled:
+  def update_set_speed(self, v_cruise_kph, v_ego, v_ego_diff, CS, buttons_enabled, speed_limit_changed, frogpilot_toggles):
+    if not buttons_enabled:
       return None
 
     long_press = False
@@ -69,10 +76,12 @@ class Below28Assist:
         if speed_limit_changed:
           return None
         if b.type.raw == ButtonType.resumeCruise and self.last_below28_set_kph > 0:
+          self.reset_button_timers()
           return self.last_below28_set_kph
         if b.type.raw == ButtonType.setCruise:
           v_ego_cluster = v_ego + v_ego_diff
           set_speed_kph = v_ego_cluster * CV.MS_TO_KPH
+          self.reset_button_timers()
           return clip(round(set_speed_kph, 1), V_CRUISE_MIN, V_CRUISE_MAX)
       if b.type.raw in self.button_timers and not b.pressed:
         if self.button_timers[b.type.raw] > CRUISE_LONG_PRESS:
@@ -118,7 +127,7 @@ class Below28Assist:
 
     return v_cruise_kph
 
-  def update_button_timers(self, CS, enabled):
+  def update_button_timers(self, CS, buttons_enabled):
     for k in self.button_timers:
       if self.button_timers[k] > 0:
         self.button_timers[k] += 1
@@ -126,4 +135,4 @@ class Below28Assist:
     for b in CS.buttonEvents:
       if b.type.raw in self.button_timers:
         self.button_timers[b.type.raw] = 1 if b.pressed else 0
-        self.button_change_states[b.type.raw] = {"standstill": CS.cruiseState.standstill, "enabled": enabled}
+        self.button_change_states[b.type.raw] = {"standstill": CS.cruiseState.standstill, "enabled": buttons_enabled}

--- a/frogpilot/controls/lib/frogpilot_vcruise.py
+++ b/frogpilot/controls/lib/frogpilot_vcruise.py
@@ -4,6 +4,7 @@ from openpilot.common.realtime import DT_MDL
 from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import COMFORT_BRAKE
 
 from openpilot.frogpilot.common.frogpilot_variables import CRUISING_SPEED, PLANNER_TIME
+from openpilot.frogpilot.controls.lib.below28_assist import Below28Assist
 from openpilot.frogpilot.controls.lib.curve_speed_controller import CurveSpeedController
 from openpilot.frogpilot.controls.lib.speed_limit_controller import SpeedLimitController
 
@@ -13,11 +14,15 @@ class FrogPilotVCruise:
 
     self.csc = CurveSpeedController(self)
     self.slc = SpeedLimitController()
+    self.below28_assist = Below28Assist()
 
     self.forcing_stop = False
     self.override_force_stop = False
 
     self.override_force_stop_timer = 0
+    self.below28_assist_active = False
+    self.below28_ui_set_speed_kph = 0.0
+    self.below28_cap_mps = 0.0
 
   def update(self, gps_position, now, time_validated, v_cruise, v_ego, sm, frogpilot_toggles):
     force_stop = self.frogpilot_planner.cem.stop_light_detected and sm["controlsState"].enabled and frogpilot_toggles.force_stops
@@ -76,6 +81,18 @@ class FrogPilotVCruise:
       self.slc_offset = 0
       self.slc_target = 0
 
+    self.below28_assist.update(
+      v_cruise * CV.MS_TO_KPH,
+      v_ego_diff,
+      sm["carState"],
+      sm["controlsState"].enabled,
+      self.slc.speed_limit_changed_timer > DT_MDL,
+      frogpilot_toggles,
+    )
+    self.below28_assist_active = self.below28_assist.active
+    self.below28_ui_set_speed_kph = self.below28_assist.ui_set_speed_kph
+    self.below28_cap_mps = self.below28_assist.cap_mps
+
     if force_stop_enabled and not self.override_force_stop:
       self.forcing_stop |= not sm["carState"].standstill
 
@@ -90,6 +107,8 @@ class FrogPilotVCruise:
       targets = [self.csc_target, v_cruise]
       if frogpilot_toggles.speed_limit_controller:
         targets.append(max(self.slc.overridden_speed, self.slc_target + self.slc_offset) - v_ego_diff)
+      if self.below28_assist_active:
+        targets.append(self.below28_cap_mps)
 
       v_cruise = min([target if target >= CRUISING_SPEED else v_cruise for target in targets])
 

--- a/frogpilot/controls/lib/frogpilot_vcruise.py
+++ b/frogpilot/controls/lib/frogpilot_vcruise.py
@@ -83,6 +83,7 @@ class FrogPilotVCruise:
 
     self.below28_assist.update(
       v_cruise * CV.MS_TO_KPH,
+      v_ego,
       v_ego_diff,
       sm["carState"],
       sm["controlsState"].enabled,

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -896,6 +896,8 @@ class Controls:
     controlsState.vPid = float(self.LoC.v_pid)
     controlsState.vCruise = float(self.v_cruise_helper.v_cruise_kph)
     controlsState.vCruiseCluster = float(self.v_cruise_helper.v_cruise_cluster_kph)
+    if self.sm["frogpilotPlan"].below28AssistActive:
+      controlsState.vCruiseCluster = float(self.sm["frogpilotPlan"].below28AssistUiSetSpeedKph)
     controlsState.upAccelCmd = float(self.LoC.pid.p)
     controlsState.uiAccelCmd = float(self.LoC.pid.i)
     controlsState.ufAccelCmd = float(self.LoC.pid.f)


### PR DESCRIPTION
### Motivation
- Provide a smooth below-28 kph cruise assist that displays a custom set speed and enforces a low-speed cap via the existing SLC target chain while fixing the multi-tap "three taps" behavior. 
- Bridge the display value from the frogpilot process into `controlsd` using the `frogpilotPlan` message so `controlsd` can override the cluster UI without reading FrogPilot internals.

### Description
- Added `frogpilot/controls/lib/below28_assist.py` which implements the below-28 state machine, button tap/hold classification, kph-native stepping (uses `IMPERIAL_INCREMENT`, `CRUISE_NEAREST_FUNC`, etc.), respects `reverse_cruise_increase`, and exposes `active`, `ui_set_speed_kph`, and `cap_mps` outputs.
- Integrated the assist into `FrogPilotVCruise` by instantiating `Below28Assist`, updating it each cycle, and appending `cap_mps` into the existing min-cap target chain when active.
- Published `below28AssistActive` and `below28AssistUiSetSpeedKph` on `frogpilotPlan` and added the two fields to `cereal/custom.capnp` for cross-process messaging.
- Plumbed the display override into `selfdrive/controls/controlsd.py` so `controlsState.vCruiseCluster` is overwritten with `frogpilotPlan.below28AssistUiSetSpeedKph` when the assist is active.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968eec0cfd88329b224da0e1b7a834f)